### PR TITLE
Add run preview images to the run browser page

### DIFF
--- a/src/runs.tsx
+++ b/src/runs.tsx
@@ -3,7 +3,13 @@ import Container from '@material-ui/core/Container';
 import Typography from '@material-ui/core/Typography';
 import Box from '@material-ui/core/Box';
 import Link from '@material-ui/core/Link';
-import Catalogs from './components/catalogs';
+import { Theme, withStyles, WithStyles } from '@material-ui/core/styles';
+import Card from '@material-ui/core/Card';
+import CardActionArea from '@material-ui/core/CardActionArea';
+import CardActions from '@material-ui/core/CardActions';
+import CardContent from '@material-ui/core/CardContent';
+import CardMedia from '@material-ui/core/CardMedia';
+import Button from '@material-ui/core/Button';
 
 import {
     BrowserRouter as Router,
@@ -11,6 +17,18 @@ import {
     Link as RouterLink,
     RouteComponentProps
 } from "react-router-dom";
+
+const useStyles = (theme: Theme) => ({
+  root: {
+    maxWidth: 345,
+    minWidth: 250,
+  },
+  media: {
+    height: 250,
+  },
+});
+
+export interface IProps extends WithStyles<typeof useStyles> {}
 
 interface ICatalog {
     uid: string
@@ -23,8 +41,8 @@ type RouteParams = { id: string };
 
 interface Props extends RouteComponentProps<RouteParams> { }
 
-class RunsPage extends React.Component<Props, IState> {
-    public constructor(props: Props) {
+class RunsPage extends React.Component<Props & IProps, IState> {
+    public constructor(props: Props & IProps) {
         super(props);
         this.state = {
             catalogs: []
@@ -32,25 +50,40 @@ class RunsPage extends React.Component<Props, IState> {
     }
 
     render() {
+        const { classes } = this.props;
         return (
-          <Container maxWidth="sm">
-          <Box my={4}>
-            <Typography variant="h4" component="h1" gutterBottom>
-              This page lists runs for {this.props.match.params.id}
-              </Typography>
-              <Typography variant="h6" component="h1" gutterBottom>
-              <div>
-                <ul>
-                    {this.state.catalogs.map(catalog => (
-                        <li key={catalog.uid}>
-                            <Link color="inherit" component={RouterLink} to={"/runs/" + this.props.match.params.id + "/" + catalog.uid}>{catalog.uid}</Link>
-                        </li>
-                    ))}
-                </ul>
-              </div>
-            </Typography>
+          <div style={{ width: '100%' }}>
+              Showing {this.props.match.params.id}
+          <Box display="flex" flexWrap="wrap" p={1} m={1} bgcolor="background.paper">
+          {this.state.catalogs.map(catalog => (
+          <Card className={classes.root}>
+            <CardActionArea>
+              <CardMedia
+                className={classes.media}
+                image={"/previews/" + catalog.uid}
+                title="Run preview"
+              />
+              <CardContent>
+                <Typography gutterBottom variant="h5" component="h3">
+                  {catalog.uid}
+                </Typography>
+                <Typography variant="body2" color="textSecondary" component="p">
+                  Maybe scan notes, summary of the scan?
+                </Typography>
+              </CardContent>
+            </CardActionArea>
+            <CardActions>
+              <Button size="small" color="primary" >
+                Share
+              </Button>
+              <Button size="small" color="primary" component={RouterLink} to={"/runs/" + this.props.match.params.id + "/" + catalog.uid}>
+                More detail
+              </Button>
+            </CardActions>
+          </Card>
+          ))}
           </Box>
-        </Container>
+          </div>
         )
     }
 
@@ -66,4 +99,4 @@ class RunsPage extends React.Component<Props, IState> {
     }
 }
 
-export default RunsPage;
+export default withStyles(useStyles)(RunsPage);


### PR DESCRIPTION
This uses new API to get preview images for each run, and display some
basic information (currently just the UID) along with a link to the run
page. The Material-UI cards were used with the image, and they are
flowed in a flexbox container.